### PR TITLE
Fixed bugs

### DIFF
--- a/bam_tools/Cargo.toml
+++ b/bam_tools/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+console = { version = ">=0.9.1, <1.0.0", features=["default"] }
 byteorder = "1.2.3"
 flate2 = "1.0.1"
 num_cpus = "0.2"

--- a/gbam_tools/src/lib.rs
+++ b/gbam_tools/src/lib.rs
@@ -32,10 +32,10 @@ pub mod query {
     pub mod depth;
     pub mod flagstat;
     pub mod int2str;
-    pub mod markdup {
-        pub mod markdup;
-        mod sorted_storage;
-    }
+    //pub mod markdup {
+    //    pub mod markdup;
+    //    mod sorted_storage;
+    //}
 }
 
 


### PR DESCRIPTION


Project wouldn't compile because of dependency conflicts and missing modules in `gbam_tools/lib.rs`.


---


Tested on Debian Stable.