### PR TITLE
SAM input to gBAM

### DIFF
--- a/gbam_binary/src/main.rs
+++ b/gbam_binary/src/main.rs
@@ -178,7 +178,7 @@ fn convert_sam(args: Cli, full_command: String) {
         .unwrap();
 
     let start = Instant::now();
-    sam_to_gbam(None, out_path, Codecs::Brotli, full_command);
+    sam_to_gbam(None, out_path, Codecs::Brotli, full_command, args.thread_num);
     let duration = start.elapsed();
     println!("SAM → GBAM conversion completed in: {:.2?}", duration);
 }

--- a/gbam_binary/src/main.rs
+++ b/gbam_binary/src/main.rs
@@ -54,8 +54,6 @@ struct Cli {
     /// The path to the BAM file to read
     // #[structopt(parse(from_os_str))]
     // in_path: PathBuf,
-    #[structopt(parse(from_os_str), required_unless = "convert_sam_to_gbam")]
-    in_path: Option<PathBuf>,
     /// The path to write output GBAM file
     #[structopt(short, parse(from_os_str))]
     out_path: Option<PathBuf>,
@@ -100,6 +98,13 @@ struct Cli {
     /// Convert SAM to GBAM
     #[structopt(long)]
     convert_sam_to_gbam: bool,
+    #[structopt(
+        parse(from_os_str),
+        required_unless = "convert-sam-to-gbam",
+        name = "in-path",
+        help = "The input BAM/SAM/GBAM file. Omit when using --convert-sam-to-gbam to read from stdin."
+    )]
+    in_path: Option<PathBuf>,
 }
 
 /// Limited wrapper of `gbam_tools` converts BAM file to GBAM

--- a/gbam_tools/src/bam/bam_to_gbam.rs
+++ b/gbam_tools/src/bam/bam_to_gbam.rs
@@ -171,9 +171,9 @@ pub fn convert_sam_record_to_bam(record: &SamRecord, ref_names: &[String]) -> Ve
             }
             "f" => {
                 if let Ok(val) = value.parse::<f32>() {
-                    record.extend_from_slice(tag.as_bytes());
-                    record.extend_from_slice(b"f");
-                    record.extend_from_slice(&val.to_le_bytes());
+                    data.extend_from_slice(tag.as_bytes());
+                    data.extend_from_slice(b"f");
+                    data.extend_from_slice(&val.to_le_bytes());
                 } else {
                     eprintln!("Failed to parse float for tag {}:{}", tag, value);
                 }

--- a/gbam_tools/src/bam/bam_to_gbam.rs
+++ b/gbam_tools/src/bam/bam_to_gbam.rs
@@ -1,5 +1,6 @@
 use crate::MEGA_BYTE_SIZE;
 use crate::{Codecs, Writer};
+use crate::{SamRecord, SamHeader, SamRawRecords, SamReader};
 use bam_tools::parse_reference_sequences;
 use bam_tools::record::bamrawrecord::BAMRawRecord;
 use bam_tools::record::fields::{Fields, FIELDS_NUM};
@@ -8,10 +9,13 @@ use bam_tools::sorting::sort::TempFilesMode;
 use bam_tools::Reader;
 use std::borrow::Cow;
 use std::fs::File;
-use std::io::{BufReader, BufWriter};
+use std::io::{self, Write, BufReader, BufWriter};
 use std::path::PathBuf;
 use std::str::FromStr;
 use tempdir::TempDir;
+
+use byteorder::{LittleEndian, WriteBytesExt};
+use std::convert::TryInto;
 
 
 const MEM_LIMIT: usize = 2000 * MEGA_BYTE_SIZE;
@@ -22,12 +26,209 @@ pub fn bam_to_gbam(in_path: &str, out_path: &str, codec: Codecs, full_command: S
 
     let mut records = bam_reader.records();
     while let Some(Ok(rec)) = records.next_rec() {
-        let wrapper = BAMRawRecord(Cow::Borrowed(rec));
+        let wrapper: BAMRawRecord<'_> = BAMRawRecord(Cow::Borrowed(rec));
         writer.push_record(&wrapper);
     }
 
     writer.finish().unwrap();
 }
+
+pub fn sam_to_gbam(in_path: &str, out_path: &str, codec: Codecs, full_command: String) {
+    let (mut sam_reader, mut writer) = get_sam_reader_gbam_writer(in_path, out_path, codec, full_command);
+    let ref_names = sam_reader.reference_names();
+
+    for result in sam_reader.records() {
+        match result {
+            Ok(sam_record) => {
+                // Convert SAM to BAM record binary
+                let bam_bytes = convert_sam_record_to_bam(&sam_record, &ref_names); // Your implementation
+                // validate_bam_record(bam_bytes);
+                let wrapper = BAMRawRecord::from(bam_bytes[4..].to_vec());
+                writer.push_record(&wrapper);
+            }
+            Err(e) => {
+                eprintln!("Skipping invalid record: {}", e);
+                continue;
+            }
+        }
+    }
+
+    writer.finish().unwrap();
+}
+
+fn count_cigar_ops(cigar: &str) -> u16 {
+    let mut count = 0;
+    let mut num = false;
+
+    for c in cigar.chars() {
+        if c.is_ascii_digit() {
+            num = true;
+        } else if num {
+            count += 1;
+            num = false;
+        } else {
+            // CIGAR like "M" or "X" without number — invalid
+            return 0;
+        }
+    }
+
+    count
+}
+
+/// Converts a parsed SamRecord into a BAM binary record
+pub fn convert_sam_record_to_bam(record: &SamRecord, ref_names: &[String]) -> Vec<u8> {
+    let tid = ref_names
+        .iter()
+        .position(|r| r == &record.rname)
+        .unwrap_or(-1_i32 as usize) as i32;
+
+    let next_tid = match record.rnext.as_str() {
+        "*" => -1,
+        "=" => tid,
+        name => ref_names
+            .iter()
+            .position(|r| r == name)
+            .unwrap_or(-1_i32 as usize) as i32,
+    };
+
+    let l_read_name = record.qname.len() + 1; // including null terminator
+    let n_cigar_op = count_cigar_ops(&record.cigar);
+    let l_seq = record.seq.len();
+    let bin = 0u16; // Optional: compute bin if needed
+
+    let mut data = Vec::new();
+    data.extend_from_slice(&[0u8; 4]); // placeholder for block_size
+
+    // --- Fixed fields: total of 32 bytes ---
+    data.write_i32::<LittleEndian>(tid).unwrap();                      // refID
+    data.write_i32::<LittleEndian>(record.pos as i32 - 1).unwrap();   // pos (0-based)
+    data.write_u8(l_read_name as u8).unwrap();                        // l_read_name
+    data.write_u8(record.mapq).unwrap();                              // mapq
+    data.write_u16::<LittleEndian>(bin).unwrap();                     // bin
+    data.write_u16::<LittleEndian>(n_cigar_op).unwrap();              // n_cigar
+    data.write_u16::<LittleEndian>(record.flag).unwrap();             // flag
+    data.write_u32::<LittleEndian>(l_seq as u32).unwrap();            // l_seq
+    data.write_i32::<LittleEndian>(next_tid).unwrap();                // next_refID
+    data.write_i32::<LittleEndian>(record.pnext as i32 - 1).unwrap(); // next_pos
+    data.write_i32::<LittleEndian>(record.tlen).unwrap();             // tlen
+
+    // --- Variable-length fields ---
+    data.extend_from_slice(record.qname.as_bytes()); // read_name
+    data.push(0); // null terminator
+
+    data.extend_from_slice(&encode_cigar(&record.cigar)); // CIGAR
+    data.extend_from_slice(&encode_seq(&record.seq));     // SEQ
+    data.extend_from_slice(&encode_qual(&record.qual));   // QUAL
+
+    // Optional: Tags
+    for tag_field in &record.tags {
+        let parts: Vec<&str> = tag_field.splitn(3, ':').collect();
+        if parts.len() != 3 {
+            continue;
+        }
+
+        let tag = parts[0];
+        let type_char = parts[1];
+        let value = parts[2];
+
+        match type_char {
+            "A" => {
+                data.extend_from_slice(tag.as_bytes());
+                data.extend_from_slice(b"A");
+                data.push(value.as_bytes()[0]);
+            }
+            "i" => {
+                if let Ok(val) = value.parse::<i32>() {
+                    data.extend_from_slice(tag.as_bytes());
+                    data.extend_from_slice(b"i");
+                    data.extend_from_slice(&val.to_le_bytes());
+                }
+            }
+            "Z" => {
+                data.extend_from_slice(tag.as_bytes());
+                data.extend_from_slice(b"Z");
+                data.extend_from_slice(value.as_bytes());
+                data.push(0);
+            }
+            _ => {} // Skip unsupported types
+        }
+    }
+
+    // Patch the block size at the beginning
+    let block_size = (data.len() - 4) as u32;
+    data[0..4].copy_from_slice(&block_size.to_le_bytes());
+
+    data
+}
+
+
+fn encode_cigar(cigar: &str) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let mut num = String::new();
+
+    for ch in cigar.chars() {
+        if ch.is_ascii_digit() {
+            num.push(ch);
+        } else {
+            let len: u32 = num.parse().unwrap_or(0);
+            let op = match ch {
+                'M' => 0,
+                'I' => 1,
+                'D' => 2,
+                'N' => 3,
+                'S' => 4,
+                'H' => 5,
+                'P' => 6,
+                '=' => 7,
+                'X' => 8,
+                _ => panic!("Unsupported CIGAR op: {}", ch),
+            };
+            let code = (len << 4) | op;
+            bytes.write_u32::<LittleEndian>(code).unwrap();
+            num.clear();
+        }
+    }
+
+    bytes
+}
+
+fn encode_seq(seq: &str) -> Vec<u8> {
+    let mut result = Vec::new();
+    let mut byte = 0u8;
+    for (i, base) in seq.chars().enumerate() {
+        let code = encode_base(base);
+        if i % 2 == 0 {
+            byte = code << 4;
+        } else {
+            byte |= code;
+            result.push(byte);
+            byte = 0;
+        }
+    }
+    if seq.len() % 2 != 0 {
+        result.push(byte);
+    }
+    result
+}
+
+fn encode_qual(qual: &str) -> Vec<u8> {
+    if qual == "*" {
+        vec![0xFF]
+    } else {
+        qual.bytes().map(|b| b.saturating_sub(33)).collect()
+    }
+}
+
+fn encode_base(base: char) -> u8 {
+    match base.to_ascii_uppercase() {
+        '=' => 0,  'A' => 1,  'C' => 2,  'M' => 3,
+        'G' => 4,  'R' => 5,  'S' => 6,  'V' => 7,
+        'T' => 8,  'W' => 9,  'Y' => 10, 'H' => 11,
+        'K' => 12, 'D' => 13, 'B' => 14, 'N' => 15,
+        _   => 15,
+    }
+}
+
 
 /// Converts BAM file to GBAM file. Sorts BAM file in process. This uses the `bam_parallel` reader.
 pub fn bam_sort_to_gbam(in_path: &str, out_path: &str, codec: Codecs, mut sort_temp_mode: Option<String>, temp_dir: Option<PathBuf>, full_command: String, index_sort: bool) {
@@ -140,4 +341,40 @@ fn get_bam_reader_gbam_writer(
     );
 
     (bgzf_reader, writer)
+}
+
+fn get_sam_reader_gbam_writer(
+    in_path: &str,
+    out_path: &str,
+    codec: Codecs,
+    full_command: String,
+) -> (SamReader<BufReader<File>>, Writer<BufWriter<File>>) {
+    let fin = File::open(in_path).expect("failed");
+    let fout = File::create(out_path).expect("failed");
+
+    let file_size = fin.metadata().unwrap().len();
+
+    let buf_reader = BufReader::new(fin);
+    let buf_writer = BufWriter::new(fout);
+
+    // Create the SAM reader (parses header inside `new`)
+    let sam_reader = SamReader::new(buf_reader);
+
+    // Extract SAM header bytes and ref seqs
+    let (sam_header, _) = sam_reader.header().expect("failed to get header");
+    let ref_seqs = sam_reader.reference_sequences();
+
+    // Create GBAM writer
+    let writer = Writer::new(
+        buf_writer,
+        vec![codec; FIELDS_NUM],
+        8,
+        vec![Fields::RefID],
+        ref_seqs,
+        sam_header,
+        full_command,
+        false,
+    );
+
+    (sam_reader, writer)
 }

--- a/gbam_tools/src/bam/bam_to_gbam.rs
+++ b/gbam_tools/src/bam/bam_to_gbam.rs
@@ -169,6 +169,15 @@ pub fn convert_sam_record_to_bam(record: &SamRecord, ref_names: &[String]) -> Ve
                     data.extend_from_slice(&val.to_le_bytes());
                 }
             }
+            "f" => {
+                if let Ok(val) = value.parse::<f32>() {
+                    record.extend_from_slice(tag.as_bytes());
+                    record.extend_from_slice(b"f");
+                    record.extend_from_slice(&val.to_le_bytes());
+                } else {
+                    eprintln!("Failed to parse float for tag {}:{}", tag, value);
+                }
+            }
             "Z" => {
                 data.extend_from_slice(tag.as_bytes());
                 data.extend_from_slice(b"Z");

--- a/gbam_tools/src/compressor.rs
+++ b/gbam_tools/src/compressor.rs
@@ -140,7 +140,7 @@ pub fn compress(source: &[u8], mut dest: Vec<u8>, codec: Codecs) -> Vec<u8> {
         Codecs::Brotli => {
             dest.clear();
             {
-                let mut writer = CompressorWriter::new(&mut dest, 4096, 11, 22);
+                let mut writer = CompressorWriter::new(&mut dest, 4096, 8, 22);
                 writer.write_all(source).unwrap();
                 writer.flush().unwrap();
             }

--- a/gbam_tools/src/compressor.rs
+++ b/gbam_tools/src/compressor.rs
@@ -140,7 +140,7 @@ pub fn compress(source: &[u8], mut dest: Vec<u8>, codec: Codecs) -> Vec<u8> {
         Codecs::Brotli => {
             dest.clear();
             {
-                let mut writer = CompressorWriter::new(&mut dest, 4096, 8, 22);
+                let mut writer = CompressorWriter::new(&mut dest, 4096, 6, 22);
                 writer.write_all(source).unwrap();
                 writer.flush().unwrap();
             }

--- a/gbam_tools/src/lib.rs
+++ b/gbam_tools/src/lib.rs
@@ -52,9 +52,12 @@ pub mod writer;
 // use self::writer::Writer;
 // pub use {ParsingTemplate, Reader};
 use self::writer::Writer;
-pub use bam::bam_to_gbam::{bam_sort_to_gbam, bam_to_gbam};
+pub use bam::bam_to_gbam::{bam_sort_to_gbam, bam_to_gbam, sam_to_gbam};
 pub use meta::Codecs;
 pub use bam_tools::record::fields::Fields;
+
+mod sam_tools;
+pub use sam_tools::{SamRecord, SamHeader, SamRawRecords, SamReader};
 
 
 const U32_SIZE: usize = mem::size_of::<u32>();

--- a/gbam_tools/src/sam_tools.rs
+++ b/gbam_tools/src/sam_tools.rs
@@ -1,0 +1,266 @@
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Write};
+use byteorder::{LittleEndian, WriteBytesExt};
+
+/// A SAM record consists of fields separated by tabs
+#[derive(Debug, Clone)]
+pub struct SamRecord {
+    pub qname: String,
+    pub flag: u16,
+    pub rname: String,
+    pub pos: u32,
+    pub mapq: u8,
+    pub cigar: String,
+    pub rnext: String,
+    pub pnext: u32,
+    pub tlen: i32,
+    pub seq: String,
+    pub qual: String,
+    pub tags: Vec<String>,
+}
+
+impl SamRecord {
+    pub fn from_line(line: &str) -> Option<Self> {
+        let parts: Vec<&str> = line.split('\t').collect();
+        if parts.len() < 11 {
+            return None;
+        }
+
+        Some(SamRecord {
+            qname: parts[0].to_string(),
+            flag: parts[1].parse().ok()?,
+            rname: parts[2].to_string(),
+            pos: parts[3].parse().ok()?,
+            mapq: parts[4].parse().ok()?,
+            cigar: parts[5].to_string(),
+            rnext: parts[6].to_string(),
+            pnext: parts[7].parse().ok()?,
+            tlen: parts[8].parse().ok()?,
+            seq: parts[9].to_string(),
+            qual: parts[10].to_string(),
+            tags: parts[11..].iter().map(|s| s.to_string()).collect(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SamHeader {
+    pub lines: Vec<String>,
+}
+
+impl SamHeader {
+    pub fn as_bytes_and_offset(&self) -> io::Result<(Vec<u8>, usize)> {
+        let joined = self.lines.join("\n") + "\n";
+        let text_bytes = joined.as_bytes();
+        let l_text = text_bytes.len();
+
+        let mut bytes = Vec::new();
+        {
+            // Use a temporary scope and reference to avoid move issues
+            let bytes_ref = &mut bytes;
+            bytes_ref.write_u32::<LittleEndian>(l_text as u32)?;
+            bytes_ref.write_all(text_bytes)?;
+        }
+
+        let offset = bytes.len();
+        Ok((bytes, offset))
+    }
+
+    pub fn reference_names(&self) -> Vec<String> {
+        self.lines
+            .iter()
+            .filter(|line| line.starts_with("@SQ"))
+            .filter_map(|line| {
+                for field in line.split('\t') {
+                    if let Some(name) = field.strip_prefix("SN:") {
+                        return Some(name.to_string());
+                    }
+                }
+                None
+            })
+            .collect()
+    }
+
+    pub fn parse_reference_sequences(&self) -> Vec<(String, u32)> {
+        self.lines
+            .iter()
+            .filter(|line| line.starts_with("@SQ"))
+            .filter_map(|line| {
+                let mut name: Option<String> = None;
+                let mut length: Option<u32> = None;
+
+                for field in line.split('\t').skip(1) {
+                    if let Some(stripped) = field.strip_prefix("SN:") {
+                        name = Some(stripped.to_string());
+                    } else if let Some(stripped) = field.strip_prefix("LN:") {
+                        length = stripped.parse::<u32>().ok();
+                    }
+                }
+
+                match (name, length) {
+                    (Some(n), Some(l)) => Some((n, l)),
+                    _ => None,
+                }
+            })
+            .collect()
+    }
+}
+
+pub struct SamReader<R: BufRead> {
+    reader: R,
+    header: SamHeader,
+}
+
+impl<R: BufRead> SamReader<R> {
+    pub fn new(mut reader: R) -> Self {
+        let mut header_lines = Vec::new();
+        let mut buffer = String::new();
+    
+        // Read and collect header lines without consuming the first record line
+        let mut position = reader.fill_buf().unwrap();
+        while !position.is_empty() {
+            let line_end = position.iter().position(|&b| b == b'\n').map(|i| i + 1);
+            if let Some(end) = line_end {
+                let line = std::str::from_utf8(&position[..end]).unwrap();
+                if line.starts_with('@') {
+                    header_lines.push(line.trim_end().to_string());
+                    reader.consume(end);
+                    position = reader.fill_buf().unwrap();
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+    
+        SamReader {
+            reader,
+            header: SamHeader { lines: header_lines },
+        }
+    }
+
+    pub fn header(&self) -> io::Result<(Vec<u8>, usize)> {
+        self.header.as_bytes_and_offset()
+    }
+
+    pub fn reference_sequences(&self) -> Vec<(String, u32)> {
+        self.header.parse_reference_sequences()
+    }
+
+    pub fn reference_names(&self) -> Vec<String> {
+        self.header.reference_names()
+    }
+
+    pub fn records(&mut self) -> SamParsedRecords<'_, R> {
+        SamParsedRecords::new(&mut self.reader)
+    }
+
+    pub fn raw_records(&mut self) -> SamRawRecords<'_, R> {
+        SamRawRecords::new(&mut self.reader)
+    }
+}
+
+// Yields parsed SamRecord from reader
+pub struct SamParsedRecords<'a, R: BufRead> {
+    reader: &'a mut R,
+    buffer: String,
+}
+
+impl<'a, R: BufRead> SamParsedRecords<'a, R> {
+    pub fn new(reader: &'a mut R) -> Self {
+        Self {
+            reader,
+            buffer: String::new(),
+        }
+    }
+}
+
+impl<'a, R: BufRead> Iterator for SamParsedRecords<'a, R> {
+    type Item = io::Result<SamRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.buffer.clear();
+        match self.reader.read_line(&mut self.buffer) {
+            Ok(0) => None,
+            Ok(_) => {
+                if self.buffer.starts_with('@') {
+                    return self.next(); // Skip header lines
+                }
+                match SamRecord::from_line(self.buffer.trim_end()) {
+                    Some(rec) => Some(Ok(rec)),
+                    None => Some(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Invalid SAM line",
+                    ))),
+                }
+            }
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+// Raw SAM record reader for &[u8] lines
+pub struct SamRawRecords<'a, R: BufRead> {
+    reader: &'a mut R,
+    buffer: Vec<u8>,
+    scratch: String,
+}
+
+impl<'a, R: BufRead> SamRawRecords<'a, R> {
+    pub fn new(reader: &'a mut R) -> Self {
+        Self {
+            reader,
+            buffer: Vec::new(),
+            scratch: String::new(),
+        }
+    }
+
+    pub fn next_rec(&mut self) -> Option<io::Result<&[u8]>> {
+        self.buffer.clear();
+        self.scratch.clear();
+
+        loop {
+            match self.reader.read_line(&mut self.scratch) {
+                Ok(0) => return None,
+                Ok(_) => {
+                    if self.scratch.starts_with('@') {
+                        self.scratch.clear();
+                        continue;
+                    }
+                    self.buffer.extend_from_slice(self.scratch.as_bytes());
+                    return Some(Ok(&self.buffer));
+                }
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+}
+
+// Convenience function to open a SAM file and return header and parsed record iterator
+// pub fn read_sam_file(
+//     path: &str,
+// ) -> io::Result<((Vec<u8>, usize), SamParsedRecords<BufReader<File>>)> {
+//     let file = File::open(path)?;
+//     let mut reader = BufReader::new(file);
+
+//     let mut header_lines = Vec::new();
+//     let mut buffer = String::new();
+
+//     while let Ok(n) = reader.read_line(&mut buffer) {
+//         if n == 0 {
+//             break;
+//         }
+//         if buffer.starts_with('@') {
+//             header_lines.push(buffer.trim_end().to_string());
+//             buffer.clear();
+//         } else {
+//             break;
+//         }
+//     }
+
+//     let header = SamHeader { lines: header_lines };
+//     let (raw_header, offset) = header.as_bytes_and_offset();
+
+//     Ok(((raw_header, offset), SamParsedRecords::new(&mut reader)))
+// }


### PR DESCRIPTION
**Logic**

- SAM record -> BAM record -> gBAM record

SAM > GBAM > SAM records are identical. But there is an issue in the rust GBAM reader code how we set SAM header. We do not set AS: tags in the header when reconverting gbam to bam. Because of that reconverted bam's header is not identical to the orginal bam's header. https://github.com/NickRoz1/gbam/blob/master/gbam_tools/src/bam/gbam_to_bam.rs#L21-L24